### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.16-buster AS BUILD
+FROM golang:1.18-bullseye AS BUILD
 
-RUN apt update && apt install -y libwebp-dev && mkdir /project
+RUN apt-get update && apt-get install -y libwebp-dev && mkdir /project
 
 WORKDIR /project
 
@@ -8,14 +8,17 @@ COPY ./ ./
 
 RUN go build
 
-FROM ubuntu AS RUNTIME
+FROM ubuntu:focal AS RUNTIME
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN ln -fs /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime \
-    && apt update \
-    && apt install -y --no-install-recommends poppler-utils libwebp6 libreoffice \
-    fonts-dejavu fonts-freefont-ttf fonts-ubuntu ttf-bitstream-vera \
-    && apt autoremove \
-    && apt clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends poppler-utils libwebp6 libreoffice \
+    openjdk-17-jre-headless fonts-dejavu fonts-freefont-ttf fonts-ubuntu ttf-bitstream-vera \
+    && update-ca-certificates \
+    && apt-get autoremove \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=BUILD /project/document-preview-microservice /


### PR DESCRIPTION
Pinned the Ubuntu version to focal. Newer is not possible due to an dependency issue.
In Debian libwebp is older then in Ubuntu causing the go application the crash

Switched apt to apt-get as apt should not be used in scripting.

The dependency changes are to try and limit the size of the final container, and force use of newer versions. Such as java, by default it uses `default-jre` which is still version 11 in focal. But jre 17 is available in the repository.